### PR TITLE
Error running on Ubuntu 12.04

### DIFF
--- a/examples/genkey.rb
+++ b/examples/genkey.rb
@@ -1,6 +1,11 @@
 #!/usr/bin/env ruby
 require 'gpgme'
 
+# newer versions of GPGME require that the library be initialized and part of
+# the process is checking the version or the library will not work at all:
+# http://does-not-exist.org/mail-archives/mutt-dev/msg14945.html
+GPGME::check_version(nil)
+
 # If you do not have gpg-agent installed, comment out the following
 # and set it as :passphrase_callback.
 #


### PR DESCRIPTION
Trying to create a new context I get the following error:

```
local@keysmith:~/ruby-gpgme$ irb
1.9.3p194 :001 > require 'gpgme'
 => true 
1.9.3p194 :002 > ctx = GPGME::Ctx.new
GPGME::Error: GPGME::Error
    from /home/local/.rvm/gems/ruby-1.9.3-p194@keysmith/gems/ruby-gpgme-1.0.7/lib/gpgme.rb:898:in `new'
    from (irb):2
    from /home/local/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'
1.9.3p194 :003 > 
```

And running the example genkey.rb fails as well:

```
local@keysmith:~/ruby-gpgme$ ruby ~/.rvm/gems/ruby-1.9.3-p194@keysmith/gems/ruby-gpgme-1.0.7/examples/genkey.rb 
As GNUPGHOME is not set, the generated key pair will be stored into *your* keyring.  Really proceed? (y/N) y
/home/local/.rvm/gems/ruby-1.9.3-p194@keysmith/gems/ruby-gpgme-1.0.7/lib/gpgme.rb:898:in `new': Not operational (GPGME::Error)
    from /home/local/.rvm/gems/ruby-1.9.3-p194@keysmith/gems/ruby-gpgme-1.0.7/examples/genkey.rb:38:in `<main>'
```

Any ideas?

Thanks.
