### PR TITLE
fix equality with other objects

### DIFF
--- a/lib/gpgme/key.rb
+++ b/lib/gpgme/key.rb
@@ -204,7 +204,9 @@ module GPGME
     end
 
     def ==(another_key)
-      fingerprint == another_key.fingerprint
+      if another_key.respond_to?(:fingerprint)
+        fingerprint == another_key.fingerprint
+      end
     end
 
     def inspect

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -27,6 +27,11 @@ describe GPGME::Key do
     assert_equal key1, key2
   end
 
+  it "can compare a key with any other object" do
+    key1 = GPGME::Key.find(:secret).first
+    refute_equal key1, nil
+  end
+
   describe :find do
     it "should return all by default" do
       keys = GPGME::Key.find :secret


### PR DESCRIPTION
We might want to compare a GPGME::Key with other objects that do
not respond to fingerprint.
