### PR TITLE
force lib dir to be exactly "lib" rather than variations (i.e. lib64)

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -18,7 +18,7 @@ def build(tgz, *flags)
   sys("tar xjvf #{tgz}")
 
   Dir.chdir(File.basename(tgz, '.tar.bz2')) do
-    sys("./configure --prefix=#{PREFIX} --disable-shared --enable-static --with-pic", *flags)
+    sys("./configure --prefix=#{PREFIX} --libdir=#{PREFIX}/lib --disable-shared --enable-static --with-pic", *flags)
     sys("make")
     sys("make install")
   end


### PR DESCRIPTION
Patch from issue https://github.com/ueno/ruby-gpgme/pull/17#issuecomment-13931595 without tracking the other commits I did on `master` for work
