### PR TITLE
Input was getting mangled when it was in UTF-8

### DIFF
--- a/lib/gpgme/data.rb
+++ b/lib/gpgme/data.rb
@@ -68,7 +68,7 @@ module GPGME
       # Create a new instance with internal buffer.
       def from_str(string)
         rdh = []
-        err = GPGME::gpgme_data_new_from_mem(rdh, string, string.length)
+        err = GPGME::gpgme_data_new_from_mem(rdh, string, string.bytesize)
         exc = GPGME::error_to_exception(err)
         raise exc if exc
         rdh.first


### PR DESCRIPTION
If your input is in UTF-8 it got truncated because it looks like the code assumed to be given a length in bytes, not in number of characters.
