### PR TITLE
capability in key_common not working properly.

### DIFF
--- a/lib/gpgme/key_common.rb
+++ b/lib/gpgme/key_common.rb
@@ -16,10 +16,10 @@ module GPGME
     # +:encrypt+, +:sign+, +:certify+ or +:authenticate+
     def capability
       caps = []
-      caps << :encrypt if @can_encrypt
-      caps << :sign if @can_sign
-      caps << :certify if @can_certify
-      caps << :authenticate if @can_authenticate
+      caps << :encrypt if @can_encrypt == 1
+      caps << :sign if @can_sign == 1
+      caps << :certify if @can_certify == 1
+      caps << :authenticate if @can_authenticate == 1
       caps
     end
 


### PR DESCRIPTION
Method capability in key_common is not working for me (Ruby 1.9.3 & GnuPG 2.0.22)
I made it works by adding some "== 1" conditions.
