### PR TITLE
Update required version of GPGME to 1.1.3

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,7 +10,7 @@ version, or http://rdoc.info/gems/gpgme for latest gem release.
 == Requirements
 
 * Ruby 1.8 or later
-* GPGME 1.1.2 or later
+* GPGME 1.1.3 or later
 * gpg-agent (optional, but recommended)
 
 == Installation


### PR DESCRIPTION
According to extconf.rb [1], the required version of GPGME is 1.1.3 or
above. Update the README to reflect that.

[1]: https://github.com/ueno/ruby-gpgme/blob/b09689362ad074526e8e7c4c6a4d816a8ad230a2/ext/gpgme/extconf.rb#L184-L197