### PR TITLE
Switch to use mini_portile2 for building native libraries

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -60,7 +60,7 @@ follows:
 EOS
 
   require 'rubygems'
-  require 'mini_portile'
+  require 'mini_portile2'
 
   libgpg_error_recipe = MiniPortile.new('libgpg-error', '1.21').tap do |recipe|
     recipe.target = File.join(ROOT, "ports")

--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -18,7 +18,7 @@ Made Easy). GnuPG Made Easy (GPGME) is a library designed to make access to
 GnuPG easier for applications. It provides a High-Level Crypto API for
 encryption, decryption, signing, signature verification and key management.}
 
-  s.add_runtime_dependency "mini_portile", ">= 0.5.0"
+  s.add_runtime_dependency "mini_portile2", "~>2.1.0"
 
   s.add_development_dependency "mocha",     "~> 0.9.12"
   s.add_development_dependency "minitest",  "~> 2.1.0"


### PR DESCRIPTION
One of the major enhancements in mini_portile2 is to take `configure_options` literally without running in subshell, see: https://github.com/flavorjones/mini_portile/commit/e77b90938828980e670278e1c3bf83a62515a7fd.

The compatibility fix has been made at: https://github.com/ueno/ruby-gpgme/commit/661739705e7f63934e68f6b91115227fa309fb38. Unfortunately this breaks build with mini_portile < 0.7 (currently `>= 0.5.0` in gemspec) when `ENV['CFLAGS']` is present.

A gemspec dependency update seems to be necessary. But instead of depending any of the 0.7.0.rc* release, let's go straight into v2.