### PR TITLE
Relax mini_portile2 version dependency

### DIFF
--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -18,7 +18,7 @@ Made Easy). GnuPG Made Easy (GPGME) is a library designed to make access to
 GnuPG easier for applications. It provides a High-Level Crypto API for
 encryption, decryption, signing, signature verification and key management.}
 
-  s.add_runtime_dependency "mini_portile2", "~>2.1.0"
+  s.add_runtime_dependency "mini_portile2", "~>2.1"
 
   s.add_development_dependency "mocha",     "~> 0.9.12"
   s.add_development_dependency "minitest",  "~> 2.1.0"


### PR DESCRIPTION
Relax mini_portile2 version dependency, to prevent conflicts with nokogiri 1.8.0 (which requires mini_portile2 ~>2.2.0)

Fixes #88