### PR TITLE
Expose gpgme_data_set_file_name

### DIFF
--- a/ext/gpgme/gpgme_n.c
+++ b/ext/gpgme/gpgme_n.c
@@ -469,6 +469,28 @@ rb_s_gpgme_data_set_encoding (VALUE dummy, VALUE vdh, VALUE venc)
 }
 
 static VALUE
+rb_s_gpgme_data_get_file_name (VALUE dummy, VALUE vdh)
+{
+  gpgme_data_t dh;
+
+  UNWRAP_GPGME_DATA(vdh, dh);
+  const char *result = gpgme_data_get_file_name (dh);
+  return result ? rb_str_new2 (result) : Qnil;
+}
+
+static VALUE
+rb_s_gpgme_data_set_file_name (VALUE dummy, VALUE vdh, VALUE vfile_name)
+{
+  gpgme_data_t dh;
+  gpgme_error_t err;
+
+  UNWRAP_GPGME_DATA(vdh, dh);
+  err = gpgme_data_set_file_name (dh,
+      NIL_P(vfile_name) ? NULL : StringValueCStr(vfile_name));
+  return LONG2NUM(err);
+}
+
+static VALUE
 rb_s_gpgme_new (VALUE dummy, VALUE rctx)
 {
   gpgme_ctx_t ctx;
@@ -2335,6 +2357,10 @@ Init_gpgme_n (void)
 			     rb_s_gpgme_data_get_encoding, 1);
   rb_define_module_function (mGPGME, "gpgme_data_set_encoding",
 			     rb_s_gpgme_data_set_encoding, 2);
+  rb_define_module_function (mGPGME, "gpgme_data_get_file_name",
+			     rb_s_gpgme_data_get_file_name, 1);
+  rb_define_module_function (mGPGME, "gpgme_data_set_file_name",
+			     rb_s_gpgme_data_set_file_name, 2);
 
   /* Creating Contexts */
   rb_define_module_function (mGPGME, "gpgme_new",

--- a/lib/gpgme/data.rb
+++ b/lib/gpgme/data.rb
@@ -177,6 +177,23 @@ module GPGME
     end
 
     ##
+    # Return the file name of the underlying data.
+    def file_name
+      GPGME::gpgme_data_get_file_name(self)
+    end
+
+    ##
+    # Sets the file name for this buffer.
+    #
+    # @raise [GPGME::Error::InvalidValue] if the value isn't accepted.
+    def file_name=(file_name)
+      err = GPGME::gpgme_data_set_file_name(self, file_name)
+      exc = GPGME::error_to_exception(err)
+      raise exc if exc
+      file_name
+    end
+
+    ##
     # Return the entire content of the data object as string.
     def to_s
       pos = seek(0, IO::SEEK_CUR)

--- a/test/data_test.rb
+++ b/test/data_test.rb
@@ -113,6 +113,21 @@ describe GPGME::Data do
     end
   end
 
+  describe :file_name do
+    it "has no name by default" do
+      data = GPGME::Data.new("wadus")
+      assert_nil data.file_name
+    end
+
+    it "can set file_name" do
+      data = GPGME::Data.new("wadus")
+      [ "foo.bar", nil ].each do |file_name|
+        data.file_name = file_name
+        assert_equal file_name, data.file_name
+      end
+    end
+  end
+
   describe :to_s do
     it "returns the entire content of data" do
       data = GPGME::Data.new("wadus")


### PR DESCRIPTION
When using `gpg -dv <filename>` to decrypt a file, it displays **"original file name"** that shows the name of the original file before encrypting. But when encrypting from `GPGME::Data` stream, the file name was lost. And gpg displays "-&20" or similar string as the original file name.

This commit adds the ability to set the `file_name` property of `GPGME::Data` object, this property will be displayed as **"original file name"** when decrypting with `gpg -dv` command.

This solves #99