### PR TITLE
gpgme_ctx_set_engine_info added as a new interface

### DIFF
--- a/lib/gpgme/engine.rb
+++ b/lib/gpgme/engine.rb
@@ -60,6 +60,15 @@ module GPGME
         raise exc if exc
       end
 
+      #
+      # this method is supposed to not harming the global GPG status
+      #
+      def set_info_safely(proto, ctx, file_name, home_dir)
+        err = GPGME::gpgme_ctx_set_engine_info(proto, ctx, file_name, home_dir)
+        exc = GPGME::error_to_exception(err)
+        raise exc if exc
+      end
+
       ##
       # Sets the home dir for the configuration options. This way one could,
       # for example, load the keys from a customized keychain.


### PR DESCRIPTION
Currently, ruby-gpgme's set_info contaminates the global gpg status. For example, if there are several gpg process running simultaneously, one gpg fails since the other deprives of the working repository.

Then I added a new interface called `set_info_safe`, which take context as an argument so that it does not harm the other gpg related processes.