### PR TITLE
Nokogiri 1.8.1 compatibility update

### DIFF
--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -18,7 +18,7 @@ Made Easy). GnuPG Made Easy (GPGME) is a library designed to make access to
 GnuPG easier for applications. It provides a High-Level Crypto API for
 encryption, decryption, signing, signature verification and key management.}
 
-  s.add_runtime_dependency "mini_portile2", "~>2.1"
+  s.add_runtime_dependency "mini_portile2", "~>2.3"
 
   s.add_development_dependency "mocha",     "~> 0.9.12"
   s.add_development_dependency "minitest",  "~> 2.1.0"


### PR DESCRIPTION
Currently nokogiri 1.6.x has a vulnerability and Updating to 1.8.x is blocked due to the mini_portile2 compatibility.

```
gpgme (~> 2.0) was resolved to 2.0.14, which depends on
        mini_portile2 (~> 2.1)

nokogiri (= 1.8.1) was resolved to 1.8.1, which depends on
      mini_portile2 (~> 2.3.0)
```