### PR TITLE
Don't add gem root to LOAD_PATH

### DIFF
--- a/lib/gpgme.rb
+++ b/lib/gpgme.rb
@@ -1,5 +1,3 @@
-$:.push File.expand_path("../..", __FILE__) # C extension is in the root
-
 require 'gpgme_n'
 
 # TODO without this call one can't GPGME::Ctx.new, find out why


### PR DESCRIPTION
The comment, "C extension is in the root", is no longer accurate. It's now in `ext/` which will be added to the LOAD_PATH by bundler or rubygems.