### PR TITLE
Disable running tests when configuring gpgme

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -116,7 +116,10 @@ EOS
       # GPGME 1.5.0 assumes gpgsm is present if gpgconf is found.
       # However, on some systems (e.g. Debian), they are splitted into
       # separate packages.
+      '--disable-gpgconf-test',
+      '--disable-gpg-test',
       '--disable-gpgsm-test',
+      '--disable-g13-test',
       # We only need the C API.
       '--disable-languages',
       "CFLAGS=-fPIC #{ENV["CFLAGS"]}",


### PR DESCRIPTION
This disables more tests when building gpgme. This adds a significant amount of installation time and it also currently prevents this gem from being installed on MacOS.

On MacOS, it fails with a message like the following:

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/dirkjan/github/github/vendor/gems/2.5.2/ruby/2.5.0/gems/gpgme-2.0.17/ext/gpgme
/Users/dirkjan/github/github/vendor/ruby/784b3dda879bfe72f4416b516baa08608e22d571/bin/ruby -r
./siteconf20181122-46971-oal80.rb extconf.rb
************************************************************************
IMPORTANT!  gpgme gem uses locally built versions of required C libraries,
namely libgpg-error, libassuan, and gpgme.

If this is a concern for you and you want to use the system library
instead, abort this installation process and reinstall gpgme gem as
follows:

    gem install gpgme -- --use-system-libraries

************************************************************************
Extracting libgpg-error-1.32.tar.bz2 into tmp/x86_64-apple-darwin18.2.0/ports/libgpg-error/1.32... OK
Running 'configure' for libgpg-error 1.32... OK
Running 'compile' for libgpg-error 1.32... OK
Running 'install' for libgpg-error 1.32... OK
Activating libgpg-error 1.32 (from
/Users/dirkjan/github/github/vendor/gems/2.5.2/ruby/2.5.0/gems/gpgme-2.0.17/ports/x86_64-apple-darwin18.2.0/libgpg-error/1.32)...
Extracting libassuan-2.5.1.tar.bz2 into tmp/x86_64-apple-darwin18.2.0/ports/libassuan/2.5.1... OK
Running 'configure' for libassuan 2.5.1... OK
Running 'compile' for libassuan 2.5.1... OK
Running 'install' for libassuan 2.5.1... OK
Activating libassuan 2.5.1 (from
/Users/dirkjan/github/github/vendor/gems/2.5.2/ruby/2.5.0/gems/gpgme-2.0.17/ports/x86_64-apple-darwin18.2.0/libassuan/2.5.1)...
Extracting gpgme-1.12.0.tar.bz2 into tmp/x86_64-apple-darwin18.2.0/ports/gpgme/1.12.0... OK
Running 'configure' for gpgme 1.12.0... OK
Running 'compile' for gpgme 1.12.0... ERROR, review
'/Users/dirkjan/github/github/vendor/gems/2.5.2/ruby/2.5.0/gems/gpgme-2.0.17/ext/gpgme/tmp/x86_64-apple-darwin18.2.0/ports/gpgme/1.12.0/compile.log'
to see what happened. Last lines are:
========================================================================
gpg: can't connect to the agent: File name too long
gpg: key 58CB9A4C85A81F38: public key "Tango Test (demo key) <tango@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: key A94C0F75653244D6: public key "Uniform Test (demo key) <uniform@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: key 47AF4B6961F04784: public key "Victor Test (demo key) <victor@example.org>" imported
gpg: can't connect to the agent: File name too long
gpg: key DEF0F7B8EC67DBDE: public key "Whisky Test (demo key) <whisky@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: key 8979A6C5567FB34A: public key "XRay Test (demo key) <xray@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: key 9EEF34CD4B11B25F: public key "Yankee Test (demo key) <yankee@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: key 6BC4778054ACD246: public key "Zulu Test (demo key) <zulu@example.net>" imported
gpg: can't connect to the agent: File name too long
gpg: Total number processed: 26
gpg:               imported: 26
make[2]: *** [pubring-stamp] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all-recursive] Error 1
========================================================================
*** extconf.rb failed ***
```

With this change, installing the gpgme gem succeeds.