### PR TITLE
Remove has_rdoc from gemspec

### DIFF
--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.extensions        = ['ext/gpgme/extconf.rb']
   s.files             = Dir['{lib,ext,test,examples}/**/*'] +
                         Dir['ports/archives/*']
-  s.has_rdoc          = true
   s.rubyforge_project = 'ruby-gpgme'
   s.homepage          = 'http://github.com/ueno/ruby-gpgme'
   s.license           = 'LGPL-2.1+'


### PR DESCRIPTION
Gem specification attribute #has_rdoc is deprecated and ignored. According to deprecation warning, it may be removed "on or after 2018-12-01" with no replacement.

This attribute used to describe whether RDoc can be generated for given gem or not.  According to RubyGems v1.3.3 release notes, "RDoc is now generated regardless of Gem::Specification#has_rdoc?".

See:
- https://blog.rubygems.org/2009/05/04/1.3.3-released.html