### PR TITLE
Enable minimal key exports.

### DIFF
--- a/lib/gpgme/ctx.rb
+++ b/lib/gpgme/ctx.rb
@@ -370,8 +370,8 @@ module GPGME
     #
     # If passed, the key will be exported to +keydata+, which must be
     # a {GPGME::Data} object.
-    def export_keys(recipients, keydata = Data.new)
-      err = GPGME::gpgme_op_export(self, recipients, 0, keydata)
+    def export_keys(recipients, keydata = Data.new, mode=0)
+      err = GPGME::gpgme_op_export(self, recipients, mode, keydata)
       exc = GPGME::error_to_exception(err)
       raise exc if exc
       keydata

--- a/lib/gpgme/key.rb
+++ b/lib/gpgme/key.rb
@@ -81,6 +81,7 @@ module GPGME
       # @param [Hash] options
       #   * +:output+ specify where to write the key to. It will be converted to
       #     a {GPGME::Data}, so it could be a file, for example.
+      #   * +:minimal+ set to true to let the export mode be 'minimal'.
       #   * Any other option accepted by {GPGME::Ctx.new}
       #
       # @return [GPGME::Data] the exported key.
@@ -94,9 +95,14 @@ module GPGME
       #
       def export(pattern, options = {})
         output = Data.new(options[:output])
+        if options.delete(:minimal) == true
+          export_mode = 4
+        else
+          export_mode = 0
+        end
 
         GPGME::Ctx.new(options) do |ctx|
-          ctx.export_keys(pattern, output)
+          ctx.export_keys(pattern, output, export_mode)
         end
 
         output.seek(0)

--- a/test/ctx_test.rb
+++ b/test/ctx_test.rb
@@ -404,6 +404,26 @@ RUBY
       import_keys # If the test fails for some reason, it won't break others.
     end
 
+    it "exports a minimal key if given the mode" do
+      remove_all_keys
+      GPGME::Key.import(KEY_WITH_SIGNATURE[:public])
+      key = GPGME::Key.find(KEY_WITH_SIGNATURE[:sha]).first
+      output_normal = GPGME::Data.new
+      output_minimal = GPGME::Data.new
+      ctx = GPGME::Ctx.new
+
+      ctx.export_keys(key.sha, output_normal)
+      ctx.export_keys(key.sha, output_minimal, 4)
+
+      output_normal.seek(0)
+      output_minimal.seek(0)
+
+      assert_equal output_normal.read.size, 849
+      assert_equal output_minimal.read.size, 668
+
+      import_keys # If the test fails for some reason, it won't break others.
+    end
+
     it "exports only one key" do
       original_keys = GPGME::Key.find(:public)
       key           = original_keys.first

--- a/test/key_test.rb
+++ b/test/key_test.rb
@@ -66,13 +66,13 @@ describe GPGME::Key do
     # Testing the lazy way with expectations. I think tests in
     # the Ctx class are enough.
     it "exports any key that matches the pattern" do
-      GPGME::Ctx.any_instance.expects(:export_keys).with("", anything)
+      GPGME::Ctx.any_instance.expects(:export_keys).with("", anything, 0)
       GPGME::Key.export("")
     end
 
     it "exports any key that matches the pattern, can specify output" do
       data = GPGME::Data.new
-      GPGME::Ctx.any_instance.expects(:export_keys).with("wadus", data)
+      GPGME::Ctx.any_instance.expects(:export_keys).with("wadus", data, 0)
       ret = GPGME::Key.export("wadus", :output => data)
       assert_equal data, ret
     end
@@ -80,6 +80,11 @@ describe GPGME::Key do
     it "can specify options for Ctx" do
       GPGME::Ctx.expects(:new).with(:armor => true).yields(mock(:export_keys => true))
       GPGME::Key.export("wadus", :armor => true)
+    end
+
+    it "can export a minimal key" do
+      GPGME::Ctx.any_instance.expects(:export_keys).with("wadus", anything, 4)
+      GPGME::Key.export("wadus", :minimal => true)
     end
   end
 

--- a/test/support/resources.rb
+++ b/test/support/resources.rb
@@ -386,6 +386,31 @@ HyEbgNA=
 -----END PGP PRIVATE KEY BLOCK-----
 RUBY
 
+key_with_signature = <<-RUBY
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mI0ETbL4sAEEANBs/WsOxRCLdsW1h8LKGT6eJpAs6omGV/G7TJnMsk92BUIub3oZ
+9oRC1L0l4EKB6o8/vULziT815dbbVxwQIOyDXEqP4sokRxjSNNkpPb+RuIjdmP6e
+SJ2NxCxV/GxLhjZZTHG5SPH4Gei3TtdiHMHoar0rwEcVdS693K/6Ww8ZABEBAAG0
+IVRlc3QgbnVtYmVyIDEgPHRlc3QxQGV4YW1wbGUuY29tPoi4BBMBAgAiBQJNsviw
+AhsDBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAKCRD7yLd2W11cdyxOA/4gPEK1
+qF8bp0YJfc91Ob/J70N5gNuO06AeBa8o6MHTUheCp5CMFD8RISDegsiYey3O+Wvk
+rg+BmIQWqGTglDIDOM8B1Bmc+T+C0sRwIwmHqDo5a9mR2QnlcFqZ3SNV5MdxDUa4
+GJk4LbUj/JwU2nR8Z4eA7OC1LjOexFKAfLX654izBBABCAAdFiEEVsoxCW7JMuDZ
+Ydv9OSviynfWZWYFAl1ziQcACgkQOSviynfWZWYScwP/a/shuIWvLCZLllW0YWy8
+NUPgTZ4TnJogOp4zm9+uNla9GJepM1Wj7+m1ZNzXskqESoAB00k2dYOGwek0hPHp
+1MwpcMJvAu7m+LrfGVcG6IAkjQWvifsP8QIe05yNW3jsK+qQJpy1dejzgaHt7dLL
+/rS6ySBxhIvpo5tsfe+C8PO4jQRNsviwAQQAvVKqiSoVA6oQ8nT3zLEGDgNeED3M
+fHMeYbFMi7GTpvURsTXcPH0SLXzGVn8Aevaa+ConFWMQuWMsTPiqVQR6/kKE8RJ/
+ynDHbnXuOGNdOBd96GdsIgqTMwrtWVvzhSKFrhDB1y8iFyQ9QlVTJG4jo8EcaN6L
+T0hoo64XJktD5CUAEQEAAYifBBgBAgAJBQJNsviwAhsMAAoJEPvIt3ZbXVx3X/8E
+AIiCsyWlIOUvhFN5a/V2TyA2XjXEKSn9iWi7uLhVT7ShrWSGGhdNBwiqJuDh5KxX
+3VXa9fePMXrfbALdj1fRqCAFfKZAcKrNNls+psSaYLJwLhCUzD8Ht9M+LrGeZDPz
+wzAqTfgPb5M2Inssarr5Lpdlu1X8y37cfNVHscqBZyfS
+=KOQt
+-----END PGP PUBLIC KEY BLOCK-----
+RUBY
+
 encrypted_text = <<-RUBY
 -----BEGIN PGP MESSAGE-----
 Version: GnuPG v1.4.11 (Darwin)
@@ -504,6 +529,11 @@ EXPIRED_KEY = {
   :sha    => "test_expired@example.com",
   :public => expired_key_public,
   :secret => expired_key_secret
+}
+
+KEY_WITH_SIGNATURE = {
+  :sha    => 'test1@example.com',
+  :public => key_with_signature
 }
 
 TEXT = {


### PR DESCRIPTION
'Minimal' is the smallest possible key, all signatures removed except
for the latest self-signatures.

~~Note: I will have to fix the tests, can't run them locally due to <https://dev.gnupg.org/T4459>.~~