### PR TITLE
ctx: do not autoclose in `pass_function`

### DIFF
--- a/lib/gpgme/ctx.rb
+++ b/lib/gpgme/ctx.rb
@@ -517,6 +517,7 @@ keylist_mode=#{KEYLIST_MODE_NAMES[keylist_mode]}>"
 
     def self.pass_function(pass, uid_hint, passphrase_info, prev_was_bad, fd)
       io = IO.for_fd(fd, 'w')
+      io.autoclose = false
       io.puts pass
       io.flush
     end


### PR DESCRIPTION
Hey there! Here's a bug fix for an issue that was causing file descriptors to double-close in our test suite.

Commit message inline:

```
The default callback for writing a password to GPGME takes a file
descriptor and needs to write the given password to it. By creating a
new `IO` object directly on the file descriptor, the object will take
ownership of it. This is a problem because the file descriptor passed to
this callback will be explicitly closed by GPGME, and eventually, the
`IO` allocated in `self.pass_function` will be garbage collected,
closing the file descriptor again.

Usually, closing a file descriptor that has already been closed results
in a silent `EBADFD`, but a serious race condition can happen if the
Kernel allocates the same file descriptor (e.g. through another `open`
call in another part of your Ruby program): when GC triggers, the
FD will be closed unexpectedly.

To prevent this, simply set `IO#autoclose = false` on the `IO` object:
the garbage collector will no longer close the file descriptor on
cleanup, so the descriptor will only be closed once (in the explicit
close call performed by us).
```