### PR TITLE
Update byebug dependency for Ruby 3.x

### DIFF
--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -31,6 +31,8 @@ encryption, decryption, signing, signature verification and key management.}
     s.add_development_dependency "ruby-debug19" , "~> 0.11.6"
   when /\A2\./
     s.add_development_dependency "byebug" , "~> 3.5.1"
+  when /\A3\./
+    s.add_development_dependency "byebug" , "~> 11.1"
   else
     s.add_development_dependency "ruby-debug" , "~> 0.10.4"
   end


### PR DESCRIPTION
For Ruby 3.x use byebug 11.x. The current gemspec uses the wrong gem, and the byebug 3.5.x won't compile for me with Ruby 3.x.