### PR TITLE
Set mini_portile2 required version to be less restrictive

### DIFF
--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -17,7 +17,7 @@ Made Easy). GnuPG Made Easy (GPGME) is a library designed to make access to
 GnuPG easier for applications. It provides a High-Level Crypto API for
 encryption, decryption, signing, signature verification and key management.}
 
-  s.add_runtime_dependency "mini_portile2", "~>2.7.0"
+  s.add_runtime_dependency "mini_portile2", "~> 2.7"
 
   s.add_development_dependency "mocha",     "~> 0.9.12"
   s.add_development_dependency "minitest",  "~> 2.1.0"


### PR DESCRIPTION
This PR makes the required version of `mini_portile2` less restrictive so it can be installed in projects that already have anything greater than `2.7` and less than version 3 of the `mini_portile2` gem  installed. 