### PR TITLE
Improve checks for pkg-config and fall back to gpgme-config

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -37,13 +37,16 @@ if arg_config('--clean')
 end
 
 if arg_config('--use-system-libraries', ENV['RUBY_GPGME_USE_SYSTEM_LIBRARIES'])
-  unless find_executable('pkg-config')
-    $stderr.puts("pkg-config not found")
+  if find_executable('pkg-config') && system('pkg-config gpgme --exists')
+    $CFLAGS += ' ' << `pkg-config --cflags gpgme`.chomp
+    $libs += ' ' << `pkg-config --libs gpgme`.chomp
+  elsif find_executable('gpgme-config')
+    $CFLAGS += ' ' << `gpgme-config --cflags`.chomp
+    $libs += ' ' << `gpgme-config --libs`.chomp
+  else
+    $stderr.puts("pkg-config with gpgme.pc and gpgme-config not found")
     exit(1)
   end
-
-  $CFLAGS += ' ' << `pkg-config --cflags gpgme`.chomp
-  $libs += ' ' << `pkg-config --libs gpgme`.chomp
 else
   message <<-'EOS'
 ************************************************************************


### PR DESCRIPTION
https://github.com/ueno/ruby-gpgme/pull/166 changed from `pkg-config` to `gpgme-config`, but if `PKG_CONFIG_PATH` is not set properly, the C extension library will quietly build without the right linker dependencies.

To fix this, we now check for the existence of `gpgme.pc` in `PKG_CONFIG_PATH` and attempt to fall back to `gpgme-config` if it does not exist.

Closes https://github.com/ueno/ruby-gpgme/issues/167