### PR TITLE
Fix: incompatible function pointer types with gpgme_op_keylist_ext_start

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+2.0.23 July 21, 2023
+
+- Fix: incompatible function pointer types with “gpgme_op_keylist_ext_start” (Clang 16)
+
 2.0.22 November 25, 2022
 
 - Make mini_portile2 less restrictive (#163)

--- a/ext/gpgme/gpgme_n.c
+++ b/ext/gpgme/gpgme_n.c
@@ -879,7 +879,7 @@ rb_s_gpgme_op_keylist_start (VALUE dummy, VALUE vctx, VALUE vpattern,
 // https://github.com/rwinlib/gpgme/blob/v1.16.0/include/gpgme.h#L2013-L2015
 static VALUE
 rb_s_gpgme_op_keylist_ext_start (VALUE dummy, VALUE vctx, VALUE vpattern,
-                                 VALUE vsecret_only, VALUE vreserved)
+                                 VALUE vsecret_only)
 {
   gpgme_ctx_t ctx;
   const char **pattern = NULL;
@@ -2424,7 +2424,7 @@ Init_gpgme_n (void)
   rb_define_module_function (mGPGME, "gpgme_op_keylist_start",
                              rb_s_gpgme_op_keylist_start, 3);
   rb_define_module_function (mGPGME, "gpgme_op_keylist_ext_start",
-                             rb_s_gpgme_op_keylist_ext_start, 4);
+                             rb_s_gpgme_op_keylist_ext_start, 3);
   rb_define_module_function (mGPGME, "gpgme_op_keylist_next",
                              rb_s_gpgme_op_keylist_next, 2);
   rb_define_module_function (mGPGME, "gpgme_op_keylist_end",

--- a/ext/gpgme/gpgme_n.c
+++ b/ext/gpgme/gpgme_n.c
@@ -876,9 +876,10 @@ rb_s_gpgme_op_keylist_start (VALUE dummy, VALUE vctx, VALUE vpattern,
   return LONG2NUM(err);
 }
 
+// https://github.com/rwinlib/gpgme/blob/v1.16.0/include/gpgme.h#L2013-L2015
 static VALUE
 rb_s_gpgme_op_keylist_ext_start (VALUE dummy, VALUE vctx, VALUE vpattern,
-                                 VALUE vsecret_only)
+                                 VALUE vsecret_only, VALUE vreserved)
 {
   gpgme_ctx_t ctx;
   const char **pattern = NULL;

--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'gpgme'
-  s.version           = '2.0.22'
+  s.version           = '2.0.23'
   s.authors           = ['Daiki Ueno', 'Albert Llop']
   s.date              = '2022-11-25'
   s.email             = 'ueno@gnu.org'

--- a/lib/gpgme/version.rb
+++ b/lib/gpgme/version.rb
@@ -1,4 +1,4 @@
 module GPGME
   # The version of GPGME ruby binding you are using
-  VERSION = "2.0.22"
+  VERSION = "2.0.23"
 end


### PR DESCRIPTION
Issues: 
- [Build failure with Clang 16 (-Wincompatible-function-pointer-types)](https://github.com/ueno/ruby-gpgme/issues/171)
- [gpgme_n.c: error: incompatible function pointer types passing VALUE](https://bugs.gentoo.org/881203)

Fix explanation: Update the method `rb_s_gpgme_op_keylist_ext_start` to have 1 more param `VALUE vreserved`

<img width="1193" alt="Screenshot 2023-07-23 at 14 41 58" src="https://github.com/ueno/ruby-gpgme/assets/1097697/f2bda5d4-431e-48dd-8f6c-4cd6964f2000">


Ref: 
- https://wiki.gentoo.org/wiki/Modern_C_porting
- https://github.com/rwinlib/gpgme/blob/v1.16.0/include/gpgme.h#L2013-L2015

I also update the version from 2.0.22 to 2.0.23 so that everyone having this issue can update to this latest version to get it fixed. 

Below is the verification result of this PR:

Command to run: `rake compile` 

BEFORE (with the master branch, version 2.0.22): 1 error
<img width="1459" alt="Screenshot 2023-07-23 at 14 57 34" src="https://github.com/ueno/ruby-gpgme/assets/1097697/ad446e8c-e40a-4a39-a186-d8e835f1374f">


AFTER (with the local branch `fix_incompatible_fn_clang16`): no more error
<img width="1461" alt="Screenshot 2023-07-23 at 14 58 40" src="https://github.com/ueno/ruby-gpgme/assets/1097697/62a9fcaf-0771-4861-8b26-16788b227ffd">

