### PR TITLE
Revert comment about cleaning not being on by default

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -2,8 +2,8 @@ require 'mkmf'
 
 # Available options:
 #
-# --enable-clean
-# --disable-clean (default)
+# --enable-clean (default)
+# --disable-clean
 #
 # This file is largely based on Nokogiri's extconf.rb.
 


### PR DESCRIPTION
Cleaning is on by default; it's just that prior to #168 the cleaning was quietly failing:

```
Cleaning files only used during build.
/Users/stanhu/.asdf/installs/ruby/3.1.4/lib/ruby/3.1.0/fileutils.rb:637:in `rm_rf': wrong number of arguments (given 2, expected 1) (ArgumentError)
	from ./extconf.rb:28:in `block in <main>'
	from <internal:dir>:220:in `glob'
	from ./extconf.rb:27:in `glob'
	from ./extconf.rb:27:in `<main>'
make: [clean-ports] Error 1 (ignored)
```