### PR TITLE
Add workaround for building gpgme with musl >= 1.2.4

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -126,7 +126,7 @@ EOS
       '--disable-g13-test',
       # We only need the C API.
       '--disable-languages',
-      "CFLAGS=-fPIC #{ENV["CFLAGS"]}",
+      "CFLAGS=-D_LARGEFILE64_SOURCE -fPIC #{ENV["CFLAGS"]}",
     ]
     checkpoint = "#{recipe.target}/#{recipe.name}-#{recipe.version}-#{recipe.host}.installed"
     unless File.exist?(checkpoint)


### PR DESCRIPTION
When trying to compile this with a current alpine linux, the build fails [because of an upgrade of musl](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.18.0). [musl 1.2.4 removed the LFS64 interfaces](https://musl.libc.org/releases.html), which are used in gpgme. They provide a way to reenable them until sources are updated with `CFLAGS=-D_LARGEFILE64_SOURCE`.

This adds the workaround to the build config until gpgme updates their code.

Here's a stacktrace of the installation without this patch: https://gist.github.com/jk779/33a16851bbe3c6baf7a024eba1fb7dc3

----
See https://github.com/ueno/ruby-gpgme/issues/182