### PR TITLE
Add Ruby 3.3 to the CI pipeline matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.1', '3.0', '2.7']
+        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Add Ruby 3.3 to the CI pipeline matrix to ensure compatibility with this version.