### PR TITLE
Set PKG_CONFIG_PATH to ensure gpgme builds with local libassuan

### DIFF
--- a/ext/gpgme/extconf.rb
+++ b/ext/gpgme/extconf.rb
@@ -106,6 +106,16 @@ EOS
     recipe.activate
   end
 
+  pkg_config_paths = [
+    File.join(libgpg_error_recipe.lib_path, 'pkgconfig'),
+    File.join(libassuan_recipe.lib_path, 'pkgconfig'),
+  ]
+
+  # Ensure that the locally-built libraries take precedence. gpgme runs
+  # `gpgrt-config libassuan` and could pull in the system libassuan
+  # if PKG_CONFIG_PATH is not set properly.
+  ENV["PKG_CONFIG_PATH"] = [*pkg_config_paths, ENV["PKG_CONFIG_PATH"]].compact.join(File::PATH_SEPARATOR)
+
   gpgme_recipe = MiniPortile.new('gpgme', '1.21.0').tap do |recipe|
     recipe.target = File.join(ROOT, "ports")
     recipe.files = [{


### PR DESCRIPTION
We had some build failures on macOS with this error:

```
configure: Use gpgrt-config as libassuan-config
checking for LIBASSUAN - version >= 2.4.2... yes (3.0.1)
checking LIBASSUAN API version... does not match.  want=2 got=3.
```

This occurs when:

1. libassuan v3.0 is installed.
2. `PKG_CONFIG_PATH` includes the Homebrew path of `/opt/homebrew/lib/pkgconfig`.

https://github.com/gpg/gpgme/blob/5bf3e6d0754a179b316f90a885371af99bc03ea1/m4/libassuan.m4#L32 attempts to run `gpgrt-config libassuan --exists`. This will return the Homebrew version of libassuan if `PKG_CONFIG_PATH` includes it.

To avoid this build failure, preface `PKG_CONFIG_PATH` with the local versions of libassuan and libgpg-error.