### PR TITLE
Move recipe definitions in dependencies.yml

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -1,0 +1,7 @@
+---
+libgpg-error:
+  version: '1.47'
+  sha256: 9e3c670966b96ecc746c28c2c419541e3bcb787d1a73930f5e5f5e1bcbbb9bdb
+libassuan:
+  version: '2.5.6'
+  sha256: e9fd27218d5394904e4e39788f9b1742711c3e6b41689a31aa3380bd5aa4f426

--- a/gpgme.gemspec
+++ b/gpgme.gemspec
@@ -5,7 +5,8 @@ Gem::Specification.new do |s|
   s.date              = '2024-01-31'
   s.email             = 'ueno@gnu.org'
   s.extensions        = ['ext/gpgme/extconf.rb']
-  s.files             = Dir['{lib,ext,test,examples}/**/*'] +
+  s.files             = ['dependencies.yml'] +
+                        Dir['{lib,ext,test,examples}/**/*'] +
                         Dir['ports/archives/*']
   s.rubyforge_project = 'ruby-gpgme'
   s.homepage          = 'http://github.com/ueno/ruby-gpgme'


### PR DESCRIPTION
A similar approach is used in native gems such as re2 and nokogiri. It makes it easier to auto-update the dependencies if they are in a YAML file.