### PR TITLE
Add Ruby 3.4 to the CI pipeline matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.3', '3.2', '3.1', '3.0', '2.7']
+        ruby: ['3.4', '3.3', '3.2', '3.1', '3.0', '2.7']
         use_system_libraries: [false, true]
 
     steps:


### PR DESCRIPTION
Add Ruby 3.4 to the CI pipeline matrix to ensure compatibility with this version.

Tests pass against 3.4 locally.